### PR TITLE
Dockerfile mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@
 #    make docker-push
 FROM golang:1.20-bullseye as build
 ARG GIT_COMMIT
-ARG DATABASE_URL=DATABASE_URL_DEFAULT_VALUE
-ENV DATABASE_URL=$DATABASE_URL
 
 WORKDIR /src/stellar-disbursement-platform
 ADD go.mod go.sum ./
@@ -15,6 +13,9 @@ RUN go build -o /bin/stellar-disbursement-platform -ldflags "-X main.GitCommit=$
 
 FROM ubuntu:22.04
 
+ARG DATABASE_URL=DATABASE_URL_DEFAULT_VALUE
+ENV DATABASE_URL=$DATABASE_URL
+
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # ADD migrations/ /app/migrations/
 COPY --from=build /bin/stellar-disbursement-platform /app/
@@ -22,5 +23,5 @@ EXPOSE 8001
 WORKDIR /app
 ENTRYPOINT ["./stellar-disbursement-platform"]
 CMD ["serve"]
-RUN ./stellar-disbursement-platform db migrate up
-RUN ./stellar-disbursement-platform db auth migrate up
+RUN ./stellar-disbursement-platform --database-url=$DATABASE_URL db migrate up
+RUN ./stellar-disbursement-platform --database-url=$DATABASE_URL db auth migrate up

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 #    make docker-build
 # To push:
 #    make docker-push
-
 FROM golang:1.20-bullseye as build
 ARG GIT_COMMIT
+ARG DATABASE_URL=DATABASE_URL_DEFAULT_VALUE
+ENV DATABASE_URL=$DATABASE_URL
 
 WORKDIR /src/stellar-disbursement-platform
 ADD go.mod go.sum ./
 RUN go mod download
 ADD . ./
 RUN go build -o /bin/stellar-disbursement-platform -ldflags "-X main.GitCommit=$GIT_COMMIT" .
-
 
 FROM ubuntu:22.04
 
@@ -22,3 +22,5 @@ EXPOSE 8001
 WORKDIR /app
 ENTRYPOINT ["./stellar-disbursement-platform"]
 CMD ["serve"]
+RUN ./stellar-disbursement-platform db migrate up
+RUN ./stellar-disbursement-platform db auth migrate up

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN go build -o /bin/stellar-disbursement-platform -ldflags "-X main.GitCommit=$
 FROM ubuntu:22.04
 
 ARG DATABASE_URL=DATABASE_URL_DEFAULT_VALUE
-ENV DATABASE_URL=$DATABASE_URL
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # ADD migrations/ /app/migrations/
@@ -25,3 +24,10 @@ ENTRYPOINT ["./stellar-disbursement-platform"]
 CMD ["serve"]
 RUN ./stellar-disbursement-platform --database-url=$DATABASE_URL db migrate up
 RUN ./stellar-disbursement-platform --database-url=$DATABASE_URL db auth migrate up
+
+ARG ADMIN_MAIL=MAIL_DEFAULT_VALUE
+ARG ADMIN_NAME=NAME_DEFAULT_VALUE
+ARG ADMIN_LAST_NAME=LAST_NAME_DEFAULT_VALUE
+ARG ADMIN_PASSWORD=PASSWORD_DEFAULT_VALUE
+
+RUN echo $ADMIN_PASSWORD | ./stellar-disbursement-platform --database-url=$DATABASE_URL auth add-user $ADMIN_MAIL $ADMIN_NAME $ADMIN_LAST_NAME --password --owner --roles owner

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ ARG ADMIN_NAME=NAME_DEFAULT_VALUE
 ARG ADMIN_LAST_NAME=LAST_NAME_DEFAULT_VALUE
 ARG ADMIN_PASSWORD=PASSWORD_DEFAULT_VALUE
 
-RUN echo $ADMIN_PASSWORD | ./stellar-disbursement-platform --database-url=$DATABASE_URL auth add-user $ADMIN_MAIL $ADMIN_NAME $ADMIN_LAST_NAME --password --owner --roles owner
+RUN if [ "$ADMIN_MAIL" != "MAIL_DEFAULT_VALUE" ]; then echo $ADMIN_PASSWORD | ./stellar-disbursement-platform --database-url=$DATABASE_URL auth add-user $ADMIN_MAIL $ADMIN_NAME $ADMIN_LAST_NAME --password --owner --roles owner; \ 
+    fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stellar Disbursement Platform Backend
+# Stellar Disbursement Platform Backend.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Resume

### This PR modifies the Dockerfile file to allow migration scripts to run on `docker build`
- Run `db migrate up` and `db auth migrate up` to the database given as a `docker build` argument. Also, gives the user the option to insert a new admin user to the SDP. 

 